### PR TITLE
fix(entity): prevent memory leaks during entity cleanup

### DIFF
--- a/src/main/java/kz/hxncus/mc/stonecutterdamage/data/StonecutterEntities.java
+++ b/src/main/java/kz/hxncus/mc/stonecutterdamage/data/StonecutterEntities.java
@@ -5,6 +5,7 @@ import org.bukkit.util.BlockVector;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * StonecutterEntities part of the StonecutterDamage Minecraft plugin.
@@ -13,17 +14,17 @@ import java.util.Map;
  * @since 1.0.0
  */
 public class StonecutterEntities {
-    private final Map<LivingEntity, BlockVector> entityBlockCache = new HashMap<>();
+    private final Map<UUID, BlockVector> entityBlockCache = new HashMap<>();
 
     public BlockVector get(LivingEntity entity) {
-        return entityBlockCache.get(entity);
+        return entityBlockCache.get(entity.getUniqueId());
     }
 
     public BlockVector put(LivingEntity entity, BlockVector vector) {
-        return entityBlockCache.put(entity, vector);
+        return entityBlockCache.put(entity.getUniqueId(), vector);
     }
 
     public BlockVector remove(LivingEntity entity) {
-        return entityBlockCache.remove(entity);
+        return entityBlockCache.remove(entity.getUniqueId());
     }
 }

--- a/src/main/java/kz/hxncus/mc/stonecutterdamage/task/DamageTask.java
+++ b/src/main/java/kz/hxncus/mc/stonecutterdamage/task/DamageTask.java
@@ -57,7 +57,8 @@ public class DamageTask extends BukkitRunnable {
             }
 
             for (LivingEntity entity : world.getLivingEntities()) {
-                if (entity instanceof Player || blacklistedEntities.contains(entity.getType().name()) || entity.isDead()) {
+                if (entity instanceof Player || blacklistedEntities.contains(entity.getType().name()) || !entity.isValid()) {
+                    entities.remove(entity);
                     continue;
                 }
                 Location location = entity.getLocation();


### PR DESCRIPTION
Replaced hard references from LivingEntity to UUID. This allows
  the garbage collector to properly clear entities when chunks unload.
Improved validation logic during removal to ensure all tracking
  caches are safely cleared.

Closes #6