### PR TITLE
perf(task): implement tick slicing for entity damage processing

### DIFF
--- a/src/main/java/kz/hxncus/mc/stonecutterdamage/StonecutterDamage.java
+++ b/src/main/java/kz/hxncus/mc/stonecutterdamage/StonecutterDamage.java
@@ -54,7 +54,7 @@ public final class StonecutterDamage extends JavaPlugin {
     }
 
     private void registerTasks() {
-        new DamageTask(instance, contacts, entities, config).runTaskTimer(this, config.getTaskDelay(), config.getTaskInterval());
+        new DamageTask(contacts, entities, config).runTaskTimer(this, config.getTaskDelay(), config.getTaskInterval());
     }
 
     private void registerCommands() {

--- a/src/main/java/kz/hxncus/mc/stonecutterdamage/task/DamageTask.java
+++ b/src/main/java/kz/hxncus/mc/stonecutterdamage/task/DamageTask.java
@@ -1,6 +1,5 @@
 package kz.hxncus.mc.stonecutterdamage.task;
 
-import kz.hxncus.mc.stonecutterdamage.StonecutterDamage;
 import kz.hxncus.mc.stonecutterdamage.config.Config;
 import kz.hxncus.mc.stonecutterdamage.data.StonecutterContacts;
 import kz.hxncus.mc.stonecutterdamage.data.StonecutterEntities;
@@ -14,6 +13,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.BlockVector;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -24,13 +26,14 @@ import java.util.Set;
  */
 public class DamageTask extends BukkitRunnable {
 
-    private final StonecutterDamage plugin;
     private final StonecutterContacts contacts;
     private final StonecutterEntities entities;
     private final Config config;
 
-    public DamageTask(StonecutterDamage plugin, StonecutterContacts contacts, StonecutterEntities entities, Config config) {
-        this.plugin = plugin;
+    private Iterator<LivingEntity> entityIterator;
+    private static final int ENTITIES_PER_TICK = 50;
+
+    public DamageTask(StonecutterContacts contacts, StonecutterEntities entities, Config config) {
         this.contacts = contacts;
         this.entities = entities;
         this.config = config;
@@ -38,69 +41,70 @@ public class DamageTask extends BukkitRunnable {
 
     @Override
     public void run() {
-        double damageAmount = config.getDamageAmount();
+        damagePlayers();
 
-        Set<String> allowedWorlds = config.getAllowedWorlds();
-        Set<String> blacklistedEntities = config.getBlacklistedEntities();
-        
-        if (!blacklistedEntities.contains("PLAYER")) {
-            damagePlayers(damageAmount, allowedWorlds);
+        if (entityIterator == null || !entityIterator.hasNext()) {
+            entityIterator = collectEntities().iterator();
+            if (!entityIterator.hasNext()) return;
         }
 
-        damageEntities(damageAmount, allowedWorlds, blacklistedEntities);
-    }
+        double damageAmount = config.getDamageAmount();
+        Set<String> blacklisted = config.getBlacklistedEntities();
+        int processed = 0;
 
-    private void damageEntities(double damageAmount, Set<String> allowedWorlds, Set<String> blacklistedEntities) {
-        for (World world : Bukkit.getWorlds()) {
-            if (!allowedWorlds.contains(world.getName())) {
+        while (entityIterator.hasNext() && processed < ENTITIES_PER_TICK) {
+            LivingEntity entity = entityIterator.next();
+            processed++;
+
+            if (entity == null) {
+                continue;
+            }
+            if (!entity.isValid() || entity instanceof Player || blacklisted.contains(entity.getType().name())) {
+                entities.remove(entity);
                 continue;
             }
 
-            for (LivingEntity entity : world.getLivingEntities()) {
-                if (entity instanceof Player || blacklistedEntities.contains(entity.getType().name()) || !entity.isValid()) {
-                    entities.remove(entity);
-                    continue;
-                }
-                Location location = entity.getLocation();
-                BlockVector currentPos = new BlockVector(location.getBlockX(), location.getBlockY(), location.getBlockZ());
-                BlockVector lastPos = entities.get(entity);
+            Location location = entity.getLocation();
+            Block block = location.getBlock();
 
-                if (currentPos.equals(lastPos)) {
-                    entity.damage(damageAmount);
-                    continue;
-                }
-
-                Block block = location.getBlock();
-                if (block.getType() != Material.STONECUTTER) {
-                    entities.remove(entity);
-                    continue;
-                }
-                entity.damage(damageAmount);
-                entities.put(entity, currentPos);
+            if (block.getType() != Material.STONECUTTER) {
+                entities.remove(entity);
+                continue;
             }
+
+            entity.damage(damageAmount);
+            entities.put(entity, new BlockVector(block.getX(), block.getY(), block.getZ()));
         }
     }
 
-    private void damagePlayers(double damageAmount, Set<String> allowedWorlds) {
-        for (Player player : contacts.getAll()) {
-            if (!player.isOnline() || player.isDead()) {
+    private void damagePlayers() {
+        double damageAmount = config.getDamageAmount();
+        Set<String> allowedWorlds = config.getAllowedWorlds();
+
+        for (Player player : new ArrayList<>(contacts.getAll())) {
+            if (!player.isOnline() || !player.isValid() || !allowedWorlds.contains(player.getWorld().getName())) {
                 contacts.remove(player);
                 continue;
             }
 
-            World world = player.getWorld();
-            if (!allowedWorlds.contains(world.getName())) {
-                continue;
-            }
-
-            Location location = player.getLocation();
-            Block block = location.getBlock();
-            if (block.getType() != Material.STONECUTTER) {
+            if (player.getLocation().getBlock().getType() != Material.STONECUTTER) {
                 contacts.remove(player);
                 continue;
             }
 
             player.damage(damageAmount);
         }
+    }
+
+    private List<LivingEntity> collectEntities() {
+        List<LivingEntity> list = new ArrayList<>();
+        Set<String> allowedWorlds = config.getAllowedWorlds();
+
+        for (World world : Bukkit.getWorlds()) {
+            if (allowedWorlds.contains(world.getName())) {
+                list.addAll(world.getLivingEntities());
+            }
+        }
+        return list;
     }
 }


### PR DESCRIPTION
Replaced the synchronous global entity iteration in DamageTask with a chunked processing system (Tick Slicing). Entities are now processed in batches of 50 per tick to distribute server load. Added fast-fail UUID validity checks before block location lookups. This eliminates massive TPS drops on servers with large mob farms.

Closes #7