### PR TITLE
fix(listener): remove player from contacts on disconnect

### DIFF
--- a/src/main/java/kz/hxncus/mc/stonecutterdamage/listener/StonecutterListener.java
+++ b/src/main/java/kz/hxncus/mc/stonecutterdamage/listener/StonecutterListener.java
@@ -8,9 +8,10 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 /**
  * StonecutterListener part of the stonecutter-damage Minecraft plugin.
@@ -56,5 +57,11 @@ public class StonecutterListener implements Listener {
         }
 
         contacts.add(player);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        contacts.remove(player);
     }
 }


### PR DESCRIPTION
Add onPlayerQuit method in StonecutterListener class to instantly clear redundant player data from StonecutterContacts when a player leaves the server, preventing minor memory overhead.

Closes #8